### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN mvn package
 
 FROM openjdk:15-alpine
 COPY --from=build target/geyser-connect-*.jar geyser-connect.jar
-RUN java -jar geyser-connect.jar
+CMD java -jar geyser-connect.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM maven:latest AS build
+COPY . .
+RUN mvn package
+# Result is in /target/geyser-connect-(...).jar
+
+FROM openjdk:15-alpine
+COPY --from=build target/geyser-connect-*.jar geyser-connect.jar
+RUN java -jar geyser-connect.jar


### PR DESCRIPTION
Currently no CI build exists for GeyserConnect, which means the method of writing a Dockerfile that Geyser itself uses, that being of just downloading a jar from the build server, isn't currently possible. It is also generally good practise to contain the build and execution process inside the Dockerfile.
With that in mind I have included a simple Dockerfile which runs through the build and run processes.