### PR TITLE
Update GitHub Actions.

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -5,24 +5,25 @@ on: [pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/cache@v1
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Set up JDK 16
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 16
+          distribution: 'temurin'
+          java-version: 17
       - name: Build with Maven
         run: mvn -B package
       - name: Archive artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         if: success()
         with:
           name: Build


### PR DESCRIPTION
Same PR as [Geyser's #3351](https://github.com/GeyserMC/Geyser/pull/3351) only that Gradle does not exist in this repository and that both the "distribution" context + JDK have been updated to 17 instead.