### PR TITLE
move builds steps inside Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,4 +19,4 @@ services:
     stdin_open: true  # docker run -i
     tty: true  # docker run -t
     volumes:
-      - data:/gsc
+      - ./data:/gsc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.5"
+
+services:
+  geyser-connect:
+    image: geyser-connect
+    container_name: geyser-connect
+    restart: "unless-stopped"
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+      args:
+        JDK_IMG: eclipse-temurin
+        JDK_VER: 17-jdk-alpine
+        MAVEN_VER: 3.8.7-eclipse-temurin-17-alpine
+        COMPILE: "false"  # if false, fetch from repo
+        GC_VER: "latest"  # if COMPILE=false
+    ports:
+      - 19132/udp
+    stdin_open: true  # docker run -i
+    tty: true  # docker run -t
+    volumes:
+      - $(pwd)/data:/gsc

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,4 +19,4 @@ services:
     stdin_open: true  # docker run -i
     tty: true  # docker run -t
     volumes:
-      - $(pwd)/data:/gsc
+      - data:/gsc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,32 @@
-FROM openjdk:8-jre-slim
-RUN mkdir /gsc
+ARG JDK_IMG=eclipse-temurin
+ARG JDK_VER=17-jdk-alpine
+ARG MAVEN_VER=3.8.7-eclipse-temurin-17-alpine
+# -=-=-=-=-=-=-=-=-=-=-
+FROM maven:$MAVEN_VER AS build
+
+ARG COMPILE=false  # if false, fetch from repo
+# TODO workout correct URL for a specific version
+#ARG GC_VER="1.0-SNAPSHOT"
+#ARG GC_URL="https://repo.opencollab.dev/artifactory/maven-snapshots/org/geysermc/geyser-connect/$GC_VER/geyser-connect-${GC_VER}.jar"
+ARG GC_VER="latest"
+ARG GC_URL="https://ci.opencollab.dev//job/GeyserMC/job/GeyserConnect/job/master/lastSuccessfulBuild/artifact/target/GeyserConnect.jar"
+
+WORKDIR /target
+COPY . .
+RUN [ "$COMPILE" = "true" ] \
+ && (echo "Compiling from source..." ; mvn package ) \
+ || wget -O "/target/geyser-connect-${GC_VER}.jar" "${GC_URL}"
+# Result is in /target/geyser-connect-(...).jar
+
+# -=-=-=-=-=-=-=-=-=-=-
+FROM $JDK_IMG:$JDK_VER
+
+WORKDIR /app
+COPY --from=build /target/geyser-connect-*.jar GeyserConnect.jar
+
 WORKDIR /gsc
+VOLUME ["/gsc"]
+# do not run as root
+USER nobody
 EXPOSE 19132/udp
-CMD ["java", "-Xms1G", "-jar", "GeyserConnect.jar"]
+CMD ["java", "-Xms1G", "-jar", "/app/GeyserConnect.jar"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG COMPILE=false  # if false, fetch from repo
 #ARG GC_VER="1.0-SNAPSHOT"
 #ARG GC_URL="https://repo.opencollab.dev/artifactory/maven-snapshots/org/geysermc/geyser-connect/$GC_VER/geyser-connect-${GC_VER}.jar"
 ARG GC_VER="latest"
-ARG GC_URL="https://ci.opencollab.dev//job/GeyserMC/job/GeyserConnect/job/master/lastSuccessfulBuild/artifact/target/GeyserConnect.jar"
+ARG GC_URL="https://ci.opencollab.dev/job/GeyserMC/job/GeyserConnect/job/master/lastSuccessfulBuild/artifact/target/GeyserConnect.jar"
 
 WORKDIR /target
 COPY . .

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,23 @@
 # GeyserConnect using Docker
-This contains the docker image and a basic way of running GeyserConnect
+This contains the Docker image and a basic way of running GeyserConnect
 
 ## Setup
-1. Download GeyserConnect to a subfolder called `data`
-2. Build the docker file using `docker build -t geyser-connect .`
-3. Start geyser using this:
+1. Make a directory for data: `mkdir -m 1777 data`
+2. Set the owner: `chown nobody data`
+   This matches the user that geyser-connect runs as inside the Docker
+   container.
+3. Then use either `docker-compose` or `docker` below
+
+## Docker Compose
+1. Build with `docker-compose build`
+2. Start Geyser `docker-compose up -d`
+
+* To check logs `docker-compose logs`
+* To stop `docker-compose down`
+
+## Docker
+1. Build the Dockerfile using `docker build -t geyser-connect -f docker/Dockerfile .`
+2. Start geyser using this:
 ```
 docker run --name "geyser-c" -d --restart always -p 19132:19132/udp -v $(pwd)/data:/gsc geyser-connect
 ```


### PR DESCRIPTION
- add build stage from #1, and extend
  - optionally build from source. COMPILE=true
  - automate copying build artifact from ci.opencollab.dev.  COMPILE=false
- update baseimages to use eclipse-temurin as openjdk image is deprecated
- run as nobody, not root (security)
- add docker-compose.yml
- update docker/README.md