### PR TITLE
Ensure GC works with later firing of SessionInitializeEvent

### DIFF
--- a/src/main/java/org/geysermc/extension/connect/GeyserConnect.java
+++ b/src/main/java/org/geysermc/extension/connect/GeyserConnect.java
@@ -119,6 +119,11 @@ public class GeyserConnect implements Extension {
     @Subscribe
     public void onSessionInitialize(SessionInitializeEvent event) {
         GeyserSession session = (GeyserSession) event.connection();
+        if (config().hardPlayerLimit()) {
+            if (session.getGeyser().getSessionManager().size() >= session.getGeyser().getConfig().getMaxPlayers()) {
+                session.disconnect("disconnectionScreen.serverFull");
+            }
+        }
 
         // Change the packet handler to our own
         BedrockPacketHandler packetHandler = session.getUpstream().getSession().getPacketHandler();

--- a/src/main/java/org/geysermc/extension/connect/PacketHandler.java
+++ b/src/main/java/org/geysermc/extension/connect/PacketHandler.java
@@ -27,8 +27,9 @@ package org.geysermc.extension.connect;
 
 import org.cloudburstmc.protocol.bedrock.data.AttributeData;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacketHandler;
-import org.cloudburstmc.protocol.bedrock.packet.LoginPacket;
 import org.cloudburstmc.protocol.bedrock.packet.NetworkStackLatencyPacket;
+import org.cloudburstmc.protocol.bedrock.packet.ResourcePackChunkRequestPacket;
+import org.cloudburstmc.protocol.bedrock.packet.ResourcePackClientResponsePacket;
 import org.cloudburstmc.protocol.bedrock.packet.SetLocalPlayerAsInitializedPacket;
 import org.cloudburstmc.protocol.bedrock.packet.UpdateAttributesPacket;
 import org.cloudburstmc.protocol.common.PacketSignal;
@@ -72,19 +73,6 @@ public class PacketHandler extends UpstreamPacketHandler {
             geyserConnect.logger().info(Utils.displayName(session) + " has disconnected (" + reason + ")");
             ServerManager.unloadServers(session);
         }
-    }
-
-    @Override
-    public PacketSignal handle(LoginPacket loginPacket) {
-        // Check to see if the server is full and we have a hard player cap
-        if (geyserConnect.config().hardPlayerLimit()) {
-            if (session.getGeyser().getSessionManager().size() >= session.getGeyser().getConfig().getMaxPlayers()) {
-                session.disconnect("disconnectionScreen.serverFull");
-                return PacketSignal.HANDLED;
-            }
-        }
-
-        return super.handle(loginPacket);
     }
 
     @Override
@@ -164,6 +152,16 @@ public class PacketHandler extends UpstreamPacketHandler {
         session.getGeyser().getScheduledThread().schedule(() -> session.sendUpstreamPacket(updateAttributesPacket), 500, TimeUnit.MILLISECONDS);
 
         return super.handle(packet);
+    }
+
+    @Override
+    public PacketSignal handle(ResourcePackClientResponsePacket packet) {
+        return originalPacketHandler.handle(packet);
+    }
+
+    @Override
+    public PacketSignal handle(ResourcePackChunkRequestPacket packet) {
+        return originalPacketHandler.handle(packet);
     }
 }
 


### PR DESCRIPTION
See here: https://github.com/GeyserMC/Geyser/pull/4604/

Changes for GC:
- the packet handler is replaced at a later point in time, meaning that the loginpacket handler can be removed (with the functionality there being moved to the session init event listener).
- Need to forward `ResourcePackChunkRequestPacket` and `ResourcePackClientResponsePacket` manually to the original packet listener, as it otherwise causes NPE's caused by GC taking over the packet handler 